### PR TITLE
feat: reader theme settings (light, dark, sepia)

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,14 +1,18 @@
+import readerThemeReducer, {registerReaderThemeListeners} from "@/features/reader/store/readerThemeSlice";
 import {type Action, configureStore, type ThunkAction} from '@reduxjs/toolkit';
 
-import {listenerMiddleware} from "@/app/listenerMiddleware";
+import {listenerMiddleware, startAppListening} from "@/app/listenerMiddleware";
 import {authenticationApi, homebranchApi} from "@/shared/api/rtk-query";
 import libraryReducer from "@/features/library/store/librarySlice";
+
+registerReaderThemeListeners(startAppListening);
 
 export const store = configureStore({
     reducer: {
         [homebranchApi.reducerPath]: homebranchApi.reducer,
         [authenticationApi.reducerPath]: authenticationApi.reducer,
-        library: libraryReducer
+        library: libraryReducer,
+        readerTheme: readerThemeReducer
     },
     middleware: getDefaultMiddleware =>
         getDefaultMiddleware()

--- a/src/features/reader/components/Reader.tsx
+++ b/src/features/reader/components/Reader.tsx
@@ -1,10 +1,11 @@
+import type { ReaderThemeState } from "../types/ReaderTheme";
+import { getThemeColors } from "../types/ReaderTheme";
 import {type IReactReaderStyle, ReactReader, ReactReaderStyle} from "react-reader";
 import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import {Box, Flex, IconButton, Spinner, Text, useMediaQuery} from "@chakra-ui/react";
 import {useNavigate} from "react-router";
 import {config} from "@/shared";
 import ToastFactory from "@/app/utils/toast_handler";
-import {useColorMode} from "@/components/ui/color-mode";
 import {LuX} from "react-icons/lu";
 import type {Rendition} from "epubjs";
 import type {NavItem} from "epubjs/types/navigation";
@@ -14,6 +15,8 @@ import {useDeviceName} from "../hooks/useDeviceName";
 import {useSavePositionSync} from "../hooks/useSavePositionSync";
 import type {SavedPosition} from "@/features/reader";
 import {JumpToSavedPositionModal, type ModalCase} from "@/features/reader";
+import { useAppSelector } from "@/app/hooks";
+import { ReaderSettingsMenu } from "./ReaderSettingsMenu";
 
 function getInitialLocation(bookId: string): string | number {
     if (typeof window === "undefined") return 0;
@@ -24,6 +27,20 @@ function getInitialLocation(bookId: string): string | number {
 }
 
 const KEYBOARD_HINT_KEY = "reader-keyboard-hint-shown";
+
+function applyRenditionTheme(rendition: Rendition, themeState: ReaderThemeState) {
+    const colors = getThemeColors(themeState.mode);
+
+    rendition.themes.override("color", colors.contentText);
+    rendition.themes.override("background", colors.contentBg);
+
+    rendition.themes.fontSize(`${themeState.fontSize ?? 100}%`);
+    if (themeState.fontFamily !== 'System Default') {
+        rendition.themes.font(themeState.fontFamily);
+    } else {
+        rendition.themes.font('inherit');
+    }
+}
 
 function resolvePositionLabel(cfi: string, toc: NavItem[], spineGetter: (index: number) => {
     href: string
@@ -99,13 +116,16 @@ interface ReaderProps {
 }
 
 export function Reader({book}: ReaderProps) {
-    const {colorMode} = useColorMode();
-    const isDark = colorMode === "dark";
+    // Completely detached from global colorMode to respect reader preferences
     const navigate = useNavigate();
     const deviceName = useDeviceName();
+    const themeState = useAppSelector(state => state.readerTheme);
+    const colors = getThemeColors(themeState.mode);
 
     const [location, setLocation] = useState<string | number>(getInitialLocation(book.id));
     const renditionRef = useRef<Rendition | null>(null);
+    const themeStateRef = useRef(themeState);
+    themeStateRef.current = themeState;
     const pendingServerPosRef = useRef<SavedPosition | null>(null);
 
     const [isMobile] = useMediaQuery(["(max-width: 768px)"]);
@@ -117,7 +137,7 @@ export function Reader({book}: ReaderProps) {
 
     const [modalCase, setModalCase] = useState<ModalCase | null>(null);
 
-    const readerTheme = useResponsiveReaderTheme(isDark);
+    const readerTheme = useResponsiveReaderTheme(themeState.mode);
     const {onLocationChange} = useSavePositionSync(book.id, deviceName);
 
     const buildModalCase = useCallback((serverPos: SavedPosition, rendition: Rendition) => {
@@ -186,14 +206,8 @@ export function Reader({book}: ReaderProps) {
     useEffect(() => {
         const rendition = renditionRef.current;
         if (!rendition) return;
-        if (isDark) {
-            rendition.themes.override("color", "#e2e8f0");
-            rendition.themes.override("background", "#1a202c");
-        } else {
-            rendition.themes.override("color", "#1a202c");
-            rendition.themes.override("background", "#ffffff");
-        }
-    }, [isDark]);
+        applyRenditionTheme(rendition, themeState);
+    }, [themeState]);
 
     useEffect(() => {
         if (!showKeyboardHint || isMobile) return;
@@ -206,13 +220,7 @@ export function Reader({book}: ReaderProps) {
 
     const handleGetRendition = useCallback((rendition: Rendition) => {
         renditionRef.current = rendition;
-        if (isDark) {
-            rendition.themes.override("color", "#e2e8f0");
-            rendition.themes.override("background", "#1a202c");
-        } else {
-            rendition.themes.override("color", "#1a202c");
-            rendition.themes.override("background", "#ffffff");
-        }
+        applyRenditionTheme(rendition, themeStateRef.current);
 
         const pending = pendingServerPosRef.current;
         if (pending) {
@@ -221,7 +229,7 @@ export function Reader({book}: ReaderProps) {
                 buildModalCase(pending, rendition);
             });
         }
-    }, [isDark, buildModalCase]);
+    }, [buildModalCase]);
 
     const handleLocationChanged = useCallback(
         (newLocation: string | number) => {
@@ -252,6 +260,7 @@ export function Reader({book}: ReaderProps) {
     return (
         <>
             <Box
+                bg={colors.bg}
                 h="100dvh"
                 w="100%"
                 position="fixed"
@@ -279,14 +288,15 @@ export function Reader({book}: ReaderProps) {
                             direction="column"
                             gap={3}
                         >
-                            <Spinner size="lg" color={isDark ? "#a0aec0" : "#718096"}/>
-                            <Text color={isDark ? "#a0aec0" : "#718096"} fontSize="sm">
+                            <Spinner size="lg" color={colors.muted}/>
+                            <Text color={colors.muted} fontSize="sm">
                                 Loading book...
                             </Text>
                         </Flex>
                     }
                 />
             </Box>
+            <ReaderSettingsMenu />
             <IconButton
                 aria-label="Close reader"
                 position="fixed"
@@ -295,11 +305,11 @@ export function Reader({book}: ReaderProps) {
                 zIndex={1001}
                 borderRadius="full"
                 size="sm"
-                bg={isDark ? "rgba(45, 55, 72, 0.8)" : "rgba(255, 255, 255, 0.8)"}
-                color={isDark ? "#e2e8f0" : "#2d3748"}
+                bg={colors.btnBg}
+                color={colors.text}
                 boxShadow="md"
                 _hover={{
-                    bg: isDark ? "rgba(45, 55, 72, 1)" : "rgba(237, 242, 247, 1)",
+                    bg: colors.btnHoverBg,
                 }}
                 onClick={() => navigate(-1)}
             >
@@ -313,7 +323,7 @@ export function Reader({book}: ReaderProps) {
                     left="50%"
                     transform="translateX(-50%)"
                     zIndex={1001}
-                    bg={isDark ? "rgba(45, 55, 72, 0.9)" : "rgba(74, 85, 104, 0.9)"}
+                    bg={themeState.mode === 'dark' ? "rgba(45, 55, 72, 0.9)" : themeState.mode === 'sepia' ? "rgba(91, 70, 54, 0.9)" : "rgba(74, 85, 104, 0.9)"}
                     color="white"
                     px={4}
                     py={2}
@@ -339,105 +349,109 @@ export function Reader({book}: ReaderProps) {
     );
 }
 
-function useResponsiveReaderTheme(isDark: boolean): IReactReaderStyle {
+function useResponsiveReaderTheme(themeMode: ReaderThemeState['mode']): IReactReaderStyle {
     const [isSmallScreen] = useMediaQuery([
         "(max-width: 768px)",
     ]);
 
     return useMemo(
-        () => ({
-            ...ReactReaderStyle,
-            container: {
-                ...ReactReaderStyle.container,
-                backgroundColor: isDark ? "#1a202c" : "#ffffff",
-            },
-            readerArea: {
-                ...ReactReaderStyle.readerArea,
-                backgroundColor: isDark ? "#1a202c" : "#ffffff",
-                transition: undefined,
-            },
-            reader: {
-                ...ReactReaderStyle.reader,
-                ...(isSmallScreen && {
-                    position: "absolute" as const,
-                    top: 40,
-                    left: 8,
-                    right: 8,
-                    bottom: 8,
-                }),
-            },
-            titleArea: {
-                ...ReactReaderStyle.titleArea,
-                color: isDark ? "#a0aec0" : "#999",
-                ...(isSmallScreen && {
-                    top: 8,
-                    left: 16,
-                    right: 16,
-                    fontSize: "0.85em",
-                }),
-            },
-            arrow: {
-                ...ReactReaderStyle.arrow,
-                color: isDark ? "#a0aec0" : "#718096",
-                ...(isSmallScreen && {
-                    display: "none",
-                }),
-            },
-            arrowHover: {
-                ...ReactReaderStyle.arrowHover,
-                color: isDark ? "#e2e8f0" : "#2d3748",
-                background: isDark ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.04)",
-                borderRadius: "4px",
-            },
-            prev: {
-                ...ReactReaderStyle.prev,
-            },
-            next: {
-                ...ReactReaderStyle.next,
-            },
-            tocArea: {
-                ...ReactReaderStyle.tocArea,
-                backgroundColor: isDark ? "#2d3748" : "#f7fafc",
-            },
-            tocAreaButton: {
-                ...ReactReaderStyle.tocAreaButton,
-                color: isDark ? "#e2e8f0" : "#2d3748",
-                borderBottom: isDark ? "1px solid #4a5568" : "1px solid #e2e8f0",
-                padding: "10px 16px",
-            },
-            tocButtonExpanded: {
-                ...ReactReaderStyle.tocButtonExpanded,
-                background: isDark ? "#4a5568" : "#f2f2f2",
-            },
-            tocButton: {
-                ...ReactReaderStyle.tocButton,
-            },
-            tocButtonBar: {
-                ...ReactReaderStyle.tocButtonBar,
-                background: isDark ? "#a0aec0" : "#ccc",
-            },
-            tocButtonBarTop: {
-                ...ReactReaderStyle.tocButtonBarTop,
-            },
-            tocButtonBottom: {
-                ...ReactReaderStyle.tocButtonBottom,
-            },
-            tocBackground: {
-                ...ReactReaderStyle.tocBackground,
-            },
-            toc: {
-                ...ReactReaderStyle.toc,
-            },
-            swipeWrapper: {
-                ...ReactReaderStyle.swipeWrapper,
-            },
-            containerExpanded: {
-                ...ReactReaderStyle.containerExpanded,
-            },
-            loadingView: {
-                ...ReactReaderStyle.loadingView,
-            },
-        }),
-        [isSmallScreen, isDark],
+        () => {
+            const colors = getThemeColors(themeMode);
+
+            return {
+                ...ReactReaderStyle,
+                container: {
+                    ...ReactReaderStyle.container,
+                    backgroundColor: colors.bg,
+                },
+                readerArea: {
+                    ...ReactReaderStyle.readerArea,
+                    backgroundColor: colors.bg,
+                    transition: undefined,
+                },
+                reader: {
+                    ...ReactReaderStyle.reader,
+                    ...(isSmallScreen && {
+                        position: "absolute" as const,
+                        top: 40,
+                        left: 8,
+                        right: 8,
+                        bottom: 8,
+                    }),
+                },
+                titleArea: {
+                    ...ReactReaderStyle.titleArea,
+                    color: colors.muted,
+                    ...(isSmallScreen && {
+                        top: 8,
+                        left: 16,
+                        right: 16,
+                        fontSize: "0.85em",
+                    }),
+                },
+                arrow: {
+                    ...ReactReaderStyle.arrow,
+                    color: colors.muted,
+                    ...(isSmallScreen && {
+                        display: "none",
+                    }),
+                },
+                arrowHover: {
+                    ...ReactReaderStyle.arrowHover,
+                    color: colors.hoverText,
+                    background: colors.hoverBg,
+                    borderRadius: "4px",
+                },
+                prev: {
+                    ...ReactReaderStyle.prev,
+                },
+                next: {
+                    ...ReactReaderStyle.next,
+                },
+                tocArea: {
+                    ...ReactReaderStyle.tocArea,
+                    backgroundColor: colors.uiBg,
+                },
+                tocAreaButton: {
+                    ...ReactReaderStyle.tocAreaButton,
+                    color: colors.hoverText,
+                    borderBottom: `1px solid ${colors.uiBorder}`,
+                    padding: "10px 16px",
+                },
+                tocButtonExpanded: {
+                    ...ReactReaderStyle.tocButtonExpanded,
+                    background: colors.uiBorder,
+                },
+                tocButton: {
+                    ...ReactReaderStyle.tocButton,
+                },
+                tocButtonBar: {
+                    ...ReactReaderStyle.tocButtonBar,
+                    background: colors.muted,
+                },
+                tocButtonBarTop: {
+                    ...ReactReaderStyle.tocButtonBarTop,
+                },
+                tocButtonBottom: {
+                    ...ReactReaderStyle.tocButtonBottom,
+                },
+                tocBackground: {
+                    ...ReactReaderStyle.tocBackground,
+                },
+                toc: {
+                    ...ReactReaderStyle.toc,
+                },
+                swipeWrapper: {
+                    ...ReactReaderStyle.swipeWrapper,
+                },
+                containerExpanded: {
+                    ...ReactReaderStyle.containerExpanded,
+                },
+                loadingView: {
+                    ...ReactReaderStyle.loadingView,
+                },
+            };
+        },
+        [isSmallScreen, themeMode],
     );
 }

--- a/src/features/reader/components/ReaderSettingsMenu.tsx
+++ b/src/features/reader/components/ReaderSettingsMenu.tsx
@@ -1,0 +1,181 @@
+import { Box, Flex, Text, Button, IconButton } from "@chakra-ui/react";
+import { useAppDispatch, useAppSelector } from "@/app/hooks";
+import { setThemeMode, setFontFamily, setFontSize } from "../store/readerThemeSlice";
+import { type ThemeColorMode, getThemeColors } from "../types/ReaderTheme";
+import { LuSettings, LuMinus, LuPlus } from "react-icons/lu";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const FONT_OPTIONS = [
+    { value: "System Default", label: "System Default" },
+    { value: "serif", label: "Serif" },
+    { value: "sans-serif", label: "Sans-serif" },
+    { value: "monospace", label: "Monospace" },
+];
+
+const THEME_OPTIONS: { value: ThemeColorMode; label: string }[] = [
+    { value: "light", label: "Light" },
+    { value: "dark", label: "Dark" },
+    { value: "sepia", label: "Sepia" },
+];
+
+export function ReaderSettingsMenu() {
+    const dispatch = useAppDispatch();
+    const { mode, fontFamily, fontSize } = useAppSelector((state) => state.readerTheme);
+    const [isOpen, setIsOpen] = useState(false);
+    const menuRef = useRef<HTMLDivElement>(null);
+
+    const close = useCallback(() => setIsOpen(false), []);
+
+    useEffect(() => {
+        if (!isOpen) return;
+
+        function handleClick(e: MouseEvent) {
+            if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+                close();
+            }
+        }
+
+        document.addEventListener("pointerdown", handleClick);
+        return () => document.removeEventListener("pointerdown", handleClick);
+    }, [isOpen, close]);
+
+    useEffect(() => {
+        if (!isOpen) return;
+
+        function handleKey(e: KeyboardEvent) {
+            if (e.key === "Escape") close();
+        }
+
+        document.addEventListener("keydown", handleKey);
+        return () => document.removeEventListener("keydown", handleKey);
+    }, [isOpen, close]);
+
+    const handleSizeIncrement = () => dispatch(setFontSize(Math.min(fontSize + 10, 300)));
+    const handleSizeDecrement = () => dispatch(setFontSize(Math.max(fontSize - 10, 50)));
+
+    const colors = getThemeColors(mode);
+
+    return (
+        <Box ref={menuRef} position="fixed" top={2} right={12} zIndex={1002}>
+            <IconButton
+                aria-label="Reader Settings"
+                borderRadius="full"
+                size="sm"
+                bg={colors.btnBg}
+                color={colors.text}
+                boxShadow="md"
+                _hover={{ bg: colors.btnHoverBg }}
+                onClick={() => setIsOpen((prev) => !prev)}
+            >
+                <LuSettings />
+            </IconButton>
+
+            {isOpen && (
+                <Box
+                    position="absolute"
+                    top="100%"
+                    right={0}
+                    mt={2}
+                    p={4}
+                    bg={colors.uiBg}
+                    color={colors.text}
+                    boxShadow="lg"
+                    borderRadius="md"
+                    minW="240px"
+                    border="1px solid"
+                    borderColor={colors.uiBorder}
+                >
+                    <Flex direction="column" gap={4}>
+                        {/* Theme mode */}
+                        <Box>
+                            <Text fontSize="xs" fontWeight="semibold" textTransform="uppercase" letterSpacing="wide" mb={2} opacity={0.7}>
+                                Theme
+                            </Text>
+                            <Flex gap={2}>
+                                {THEME_OPTIONS.map(({ value, label }) => (
+                                    <Button
+                                        key={value}
+                                        size="sm"
+                                        flex={1}
+                                        onClick={() => dispatch(setThemeMode(value))}
+                                        bg={mode === value ? colors.activeBg : "transparent"}
+                                        color={colors.text}
+                                        border="1px solid"
+                                        borderColor={mode === value ? colors.text : colors.uiBorder}
+                                        fontWeight={mode === value ? "semibold" : "normal"}
+                                        _hover={{ bg: mode === value ? colors.activeBg : colors.hoverBg }}
+                                    >
+                                        {label}
+                                    </Button>
+                                ))}
+                            </Flex>
+                        </Box>
+
+                        {/* Font family */}
+                        <Box>
+                            <Text fontSize="xs" fontWeight="semibold" textTransform="uppercase" letterSpacing="wide" mb={2} opacity={0.7}>
+                                Font
+                            </Text>
+                            <Flex direction="column" gap={1}>
+                                {FONT_OPTIONS.map(({ value, label }) => (
+                                    <Button
+                                        key={value}
+                                        size="sm"
+                                        variant="ghost"
+                                        justifyContent="flex-start"
+                                        onClick={() => dispatch(setFontFamily(value))}
+                                        bg={fontFamily === value ? colors.activeBg : "transparent"}
+                                        color={colors.text}
+                                        fontWeight={fontFamily === value ? "semibold" : "normal"}
+                                        fontFamily={value === "System Default" ? "inherit" : value}
+                                        _hover={{ bg: fontFamily === value ? colors.activeBg : colors.hoverBg }}
+                                    >
+                                        {label}
+                                    </Button>
+                                ))}
+                            </Flex>
+                        </Box>
+
+                        {/* Font size */}
+                        <Box>
+                            <Text fontSize="xs" fontWeight="semibold" textTransform="uppercase" letterSpacing="wide" mb={2} opacity={0.7}>
+                                Size
+                            </Text>
+                            <Flex gap={2} align="center">
+                                <IconButton
+                                    aria-label="Decrease font size"
+                                    size="sm"
+                                    onClick={handleSizeDecrement}
+                                    disabled={fontSize <= 50}
+                                    bg="transparent"
+                                    color={colors.text}
+                                    border="1px solid"
+                                    borderColor={colors.uiBorder}
+                                    _hover={{ bg: colors.hoverBg }}
+                                >
+                                    <LuMinus />
+                                </IconButton>
+                                <Text flex={1} textAlign="center" fontSize="sm" fontWeight="medium">
+                                    {fontSize}%
+                                </Text>
+                                <IconButton
+                                    aria-label="Increase font size"
+                                    size="sm"
+                                    onClick={handleSizeIncrement}
+                                    disabled={fontSize >= 300}
+                                    bg="transparent"
+                                    color={colors.text}
+                                    border="1px solid"
+                                    borderColor={colors.uiBorder}
+                                    _hover={{ bg: colors.hoverBg }}
+                                >
+                                    <LuPlus />
+                                </IconButton>
+                            </Flex>
+                        </Box>
+                    </Flex>
+                </Box>
+            )}
+        </Box>
+    );
+}

--- a/src/features/reader/store/readerThemeSlice.ts
+++ b/src/features/reader/store/readerThemeSlice.ts
@@ -1,0 +1,75 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import type { AppStartListening } from '@/app/listenerMiddleware';
+import type { ReaderThemeState, ThemeColorMode } from '../types/ReaderTheme';
+
+const THEME_STORAGE_KEY = 'reader_theme_prefs';
+
+const loadInitialState = (): ReaderThemeState => {
+    const isSystemDark = typeof window !== 'undefined' && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const defaultState: ReaderThemeState = {
+        mode: isSystemDark ? 'dark' : 'light',
+        fontFamily: 'System Default',
+        fontSize: 100
+    };
+
+    if (typeof window === 'undefined') {
+        return defaultState;
+    }
+
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    if (stored) {
+        try {
+            const parsed = JSON.parse(stored);
+            // Deep merge to ensure no property is ever undefined
+            // (Prevents "undefined%" crashing epub.js layout computation)
+            return { ...defaultState, ...parsed };
+        } catch {
+            // Fallthrough to defaults
+        }
+    }
+
+    return defaultState;
+};
+
+const initialState: ReaderThemeState = loadInitialState();
+
+const readerThemeSlice = createSlice({
+    name: 'readerTheme',
+    initialState,
+    reducers: {
+        setThemeMode(state, action: PayloadAction<ThemeColorMode>) {
+            state.mode = action.payload;
+        },
+        setFontFamily(state, action: PayloadAction<string>) {
+            state.fontFamily = action.payload;
+        },
+        setFontSize(state, action: PayloadAction<number>) {
+            state.fontSize = action.payload;
+        }
+    }
+});
+
+export const { setThemeMode, setFontFamily, setFontSize } = readerThemeSlice.actions;
+
+export function registerReaderThemeListeners(startListening: AppStartListening) {
+    startListening({
+        actionCreator: setThemeMode,
+        effect: (_action, listenerApi) => {
+            localStorage.setItem(THEME_STORAGE_KEY, JSON.stringify(listenerApi.getState().readerTheme));
+        },
+    });
+    startListening({
+        actionCreator: setFontFamily,
+        effect: (_action, listenerApi) => {
+            localStorage.setItem(THEME_STORAGE_KEY, JSON.stringify(listenerApi.getState().readerTheme));
+        },
+    });
+    startListening({
+        actionCreator: setFontSize,
+        effect: (_action, listenerApi) => {
+            localStorage.setItem(THEME_STORAGE_KEY, JSON.stringify(listenerApi.getState().readerTheme));
+        },
+    });
+}
+
+export default readerThemeSlice.reducer;

--- a/src/features/reader/types/ReaderTheme.ts
+++ b/src/features/reader/types/ReaderTheme.ts
@@ -1,0 +1,71 @@
+export type ThemeColorMode = 'light' | 'dark' | 'sepia';
+
+export interface ReaderThemeState {
+    mode: ThemeColorMode;
+    fontFamily: string;
+    fontSize: number;
+}
+
+export interface ThemeColors {
+    text: string;
+    bg: string;
+    contentText: string;
+    contentBg: string;
+    uiBg: string;
+    uiBorder: string;
+    hoverText: string;
+    hoverBg: string;
+    btnBg: string;
+    btnHoverBg: string;
+    activeBg: string;
+    muted: string;
+}
+
+const THEME_COLOR_MAP: Record<ThemeColorMode, ThemeColors> = {
+    light: {
+        text: "#1a202c",
+        bg: "#ffffff",
+        contentText: "#1a202c",
+        contentBg: "#ffffff",
+        uiBg: "#f7fafc",
+        uiBorder: "#e2e8f0",
+        hoverText: "#2d3748",
+        hoverBg: "rgba(0,0,0,0.04)",
+        btnBg: "rgba(255, 255, 255, 0.8)",
+        btnHoverBg: "rgba(237, 242, 247, 1)",
+        activeBg: "#edf2f7",
+        muted: "#718096",
+    },
+    dark: {
+        text: "#e2e8f0",
+        bg: "#1a202c",
+        contentText: "#e2e8f0",
+        contentBg: "#1a202c",
+        uiBg: "#2d3748",
+        uiBorder: "#4a5568",
+        hoverText: "#e2e8f0",
+        hoverBg: "rgba(255,255,255,0.06)",
+        btnBg: "rgba(45, 55, 72, 0.8)",
+        btnHoverBg: "rgba(45, 55, 72, 1)",
+        activeBg: "#4a5568",
+        muted: "#a0aec0",
+    },
+    sepia: {
+        text: "#5b4636",
+        bg: "#f4ecd8",
+        contentText: "#5b4636",
+        contentBg: "#f4ecd8",
+        uiBg: "#eaddc5",
+        uiBorder: "#d5c3aa",
+        hoverText: "#483526",
+        hoverBg: "rgba(0,0,0,0.04)",
+        btnBg: "rgba(234, 221, 197, 0.8)",
+        btnHoverBg: "rgba(213, 195, 170, 1)",
+        activeBg: "#d5c3aa",
+        muted: "#7a5f45",
+    },
+};
+
+export function getThemeColors(mode: ThemeColorMode): ThemeColors {
+    return THEME_COLOR_MAP[mode];
+}


### PR DESCRIPTION
## Summary
- Add `ReaderSettingsMenu` component with theme mode (light/dark/sepia), font family, and font size controls
- Centralize all theme color resolution into a single `getThemeColors()` utility, eliminating duplicated ternary chains across components
- Move localStorage persistence out of Redux reducers into RTK listener middleware for pure reducers
- Extract `applyRenditionTheme()` helper to deduplicate epub rendition styling logic

Closes #35

## Test plan
- [ ] Open reader and verify light, dark, and sepia themes apply correctly to both the reader content and surrounding UI
- [ ] Change font family and font size and verify epub content updates
- [ ] Refresh the page and verify theme preferences persist from localStorage
- [ ] Verify the settings menu closes on click-outside and Escape key

🤖 Generated with [Claude Code](https://claude.com/claude-code)