### PR TITLE
feat: add author link from book detail page (#46)

### DIFF
--- a/src/pages/bookDetails/ui/BookDetailsPage.tsx
+++ b/src/pages/bookDetails/ui/BookDetailsPage.tsx
@@ -124,9 +124,23 @@ export default function BookDetailsPage({book}: BookDetailsPageProps) {
                 </Stack>
                 <Box flex={1}>
                     <Heading size={{base: "xl", md: "2xl"}}>{book.title}</Heading>
-                    <Text color="fg.muted" fontSize="md" mt={1}>
-                        {book.author}
-                    </Text>
+                    <Box color="fg.muted" fontSize="md" mt={1}>
+                        {book.author && book.author.trim() ? (
+                            <Link
+                                to={`/authors/${encodeURIComponent(book.author)}`}
+                                style={{textDecoration: "none", color: "inherit"}}
+                            >
+                                <Box
+                                    as="span"
+                                    _hover={{textDecoration: "underline"}}
+                                >
+                                    {book.author}
+                                </Box>
+                            </Link>
+                        ) : (
+                            <Box as="span">{book.author || "Unknown Author"}</Box>
+                        )}
+                    </Box>
                     <Separator my={4}/>
                     <Text fontSize="md" color="fg.muted">
                         Published Year: {book.publishedYear}


### PR DESCRIPTION
## Summary

This PR implements issue #46, adding a clickable author link on the book details page. Users can now easily navigate from a book to its author's page to view other books by the same author and read their biography.

## Changes

- Made the author name on the book details page a clickable link
- Links navigate to `/authors/:authorName` with proper URL encoding
- Added edge case handling for empty or whitespace-only author names
- Displays "Unknown Author" fallback when author information is missing
- Styled with hover underline effect for better user experience
- Maintains consistent styling with the existing design system

## Acceptance Criteria

✅ As a user, I can click on an author's name from a book detail page
✅ The link navigates to the author's page showing their books and bio
✅ Edge cases handled (empty authors, special characters in names)

## Testing

- Type checking passes (`npm run typecheck`)
- Build succeeds (`npm run build`)
- Edge case validation for empty/whitespace author names
- URL encoding properly handles special characters

## Screenshots

N/A - Simple link addition with hover effect