### PR TITLE
feat: downloadable books (#44)

### DIFF
--- a/src/entities/bookShelf/ui/ManageBookShelvesButton.tsx
+++ b/src/entities/bookShelf/ui/ManageBookShelvesButton.tsx
@@ -8,7 +8,7 @@ import {
     useRemoveBookFromBookShelfMutation,
 } from "@/entities/bookShelf";
 
-export function ManageBookShelvesButton({bookId, size}: { bookId: string, size?: "xs" | "sm" | "md" | "lg" }) {
+export function ManageBookShelvesButton({bookId, size, variant = "subtle"}: { bookId: string, size?: "xs" | "sm" | "md" | "lg", variant?: "subtle" | "ghost" | "outline" | "solid" | "plain" }) {
     const {data: allShelves, isLoading: shelvesLoading} = useGetBookShelvesQuery();
     const {data: bookShelves, isLoading: bookShelvesLoading} = useGetBookShelvesByBookQuery(bookId);
     const [addBook] = useAddBookToBookShelfMutation();
@@ -29,7 +29,7 @@ export function ManageBookShelvesButton({bookId, size}: { bookId: string, size?:
             <Tooltip content="Manage shelves">
                 <Box display={"inline-block"} cursor={"pointer"}>
                     <Popover.Trigger asChild>
-                        <IconButton variant="subtle" size={size}>
+                        <IconButton variant={variant} size={size}>
                             <LuLibrary/>
                         </IconButton>
                     </Popover.Trigger>

--- a/src/features/reader/components/Reader.tsx
+++ b/src/features/reader/components/Reader.tsx
@@ -3,7 +3,7 @@ import { getThemeColors } from "../types/ReaderTheme";
 import {type IReactReaderStyle, ReactReader, ReactReaderStyle} from "react-reader";
 import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import {Box, Flex, IconButton, Spinner, Text, useMediaQuery} from "@chakra-ui/react";
-import {getStoredProgress, storeProgress} from "../utils/readingProgress";
+import {getStoredProgress, storeProgress} from "@/features/reader";
 import {getOrGenerateLocations} from "../utils/epubLocations";
 import {useNavigate} from "react-router";
 import {config} from "@/shared";
@@ -317,7 +317,8 @@ export function Reader({book}: ReaderProps) {
                 zIndex={1000}
             >
                 <ReactReader
-                    url={`${config.apiUrl}/uploads/books/${book.fileName}`}
+                    url={`${config.apiUrl}/books/${book.id}/download`}
+                    epubInitOptions={{ openAs: 'epub' }}
                     title={book.title}
                     location={location}
                     locationChanged={handleLocationChanged}

--- a/src/pages/bookDetails/ui/BookDetailsPage.tsx
+++ b/src/pages/bookDetails/ui/BookDetailsPage.tsx
@@ -1,9 +1,8 @@
-import {DeleteConfirmationDialog} from "@/components/ui/modals/DeleteConfirmationDialog";
 import {type BookModel, useDeleteBookMutation, useUpdateBookMutation} from "@/entities/book";
 import {config} from "@/shared";
-import {Box, Flex, Heading, IconButton, Image, Progress, Separator, Stack, Text,} from "@chakra-ui/react";
+import {Box, Button, CloseButton, Dialog, Flex, Heading, IconButton, Image, Menu, Portal, Stack, Text,} from "@chakra-ui/react";
 import {useEffect, useState} from "react";
-import {LuBookOpen, LuDownload, LuHeart, LuX} from "react-icons/lu";
+import {LuBookOpen, LuDownload, LuEllipsis, LuHeart, LuLoader, LuTrash2, LuX} from "react-icons/lu";
 import {Link, useNavigate} from "react-router";
 import {ManageBookShelvesButton} from "@/entities/bookShelf";
 import {Tooltip} from "@/components/ui/tooltip";
@@ -27,6 +26,7 @@ export default function BookDetailsPage({book}: BookDetailsPageProps) {
     const [updateBook] = useUpdateBookMutation();
     const [deleteBook, {isLoading: pendingDelete}] = useDeleteBookMutation();
     const navigate = useNavigate();
+    const [deleteOpen, setDeleteOpen] = useState(false);
 
     const [isCurrentlyReading, setIsCurrentlyReading] = useState(
         isBookOpenedLocally(book.id)
@@ -69,111 +69,169 @@ export default function BookDetailsPage({book}: BookDetailsPageProps) {
     };
 
     return (
-        <Box p={4}>
-            <Flex direction={{base: "column", md: "row"}} align={{base: "center", md: "start"}} gap={6}>
-                <Stack w={{base: "160px", md: "200px"}} gap={3} flexShrink={0}>
+        <Box p={{base: 4, md: 8}}>
+            <Flex direction={{base: "column", md: "row"}} align={{base: "center", md: "start"}} gap={{base: 6, md: 10}}>
+                {/* Cover image with frosted-glass reading progress overlay */}
+                <Box flexShrink={0} position="relative" w={{base: "200px", md: "240px"}}>
                     <Image
                         src={`${config.apiUrl}/uploads/cover-images/${book.coverImageFileName}`}
                         alt={book.title}
-                        w="100%"
+                        w="full"
                         aspectRatio="2/3"
                         objectFit="cover"
-                        borderRadius="md"
+                        borderRadius="lg"
+                        boxShadow="lg"
+                        display="block"
                     />
-                    <Flex justify={{base: "start", md: "center"}} wrap="wrap" gap={1}>
-                        <DeleteConfirmationDialog
-                            title={`Delete book: ${book.title}`}
-                            loading={pendingDelete}
-                            size="sm"
-                            onSubmit={() => {
-                                deleteBook(book.id).then(result => !result.error && navigate("/"))
-                            }}
-                        />
-                        <Tooltip content={book.isFavorite ? "Unfavorite" : "Favorite"}>
-                            <IconButton
-                                variant="subtle"
-                                size="sm"
-                                onClick={() => updateBook({...book, isFavorite: !book.isFavorite})}
-                            >
-                                <LuHeart
-                                    fill={book.isFavorite ? "red" : "none"}
-                                    color={book.isFavorite ? "red" : undefined}
-                                />
-                            </IconButton>
-                        </Tooltip>
-                        <ManageBookShelvesButton bookId={book.id} size="sm"/>
-                        <Tooltip content="Read">
-                            <IconButton variant="subtle" size="sm" asChild>
-                                <Link to={`/books/${book.id}/read`}>
-                                    <LuBookOpen/>
-                                </Link>
-                            </IconButton>
-                        </Tooltip>
-                        <Tooltip content="Download">
-                            <IconButton variant="subtle" size="sm" asChild>
-                                <a
-                                    href={`${config.apiUrl}/uploads/books/${book.fileName}`}
-                                    // Replace characters invalid in filenames with underscores
-                                    download={`${book.title.replace(/[/\\:*?"<>|]/g, '_')}.epub`}
-                                >
-                                    <LuDownload/>
-                                </a>
-                            </IconButton>
-                        </Tooltip>
-                        {isCurrentlyReading && (
-                            <Tooltip content="Stop reading">
-                                <IconButton
-                                    variant="subtle"
-                                    size="sm"
-                                    onClick={() => removeCurrentlyReading(book.id)}
-                                >
-                                    <LuX/>
-                                </IconButton>
-                            </Tooltip>
-                        )}
-                    </Flex>
-                </Stack>
-                <Box flex={1}>
-                    <Heading size={{base: "xl", md: "2xl"}}>{book.title}</Heading>
-                    <Box color="fg.muted" fontSize="md" mt={1}>
-                        {book.author && book.author.trim() ? (
-                            <Link
-                                to={`/authors/${encodeURIComponent(book.author)}`}
-                                style={{textDecoration: "none", color: "inherit"}}
-                            >
-                                <Box
-                                    as="span"
-                                    _hover={{textDecoration: "underline"}}
-                                >
-                                    {book.author}
+                    {progress !== undefined && progress > 0 && (
+                        <Box
+                            position="absolute"
+                            bottom={0}
+                            left={0}
+                            right={0}
+                            bg="blackAlpha.600"
+                            backdropFilter="blur(6px)"
+                            borderBottomRadius="lg"
+                            px={3}
+                            py={2}
+                        >
+                            <Flex align="center" gap={2}>
+                                <Box flex={1} h="2px" bg="whiteAlpha.300" borderRadius="full" overflow="hidden">
+                                    <Box
+                                        w={`${Math.round(progress * 100)}%`}
+                                        h="full"
+                                        bg="white"
+                                        borderRadius="full"
+                                    />
                                 </Box>
-                            </Link>
-                        ) : (
-                            <Box as="span">{book.author || "Unknown Author"}</Box>
-                        )}
-                    </Box>
-                    <Separator my={4}/>
-                    <Text fontSize="md" color="fg.muted">
-                        Published Year: {book.publishedYear}
-                    </Text>
-                    {progress !== undefined && (
-                        <Box mt={4}>
-                            <Text fontSize="sm" color="fg.muted" mb={1}>
-                                Reading Progress — {Math.round(progress * 100)}%
-                            </Text>
-                            <Progress.Root
-                                value={Math.round(progress * 100)}
-                                maxW="300px"
-                                size="sm"
-                            >
-                                <Progress.Track>
-                                    <Progress.Range/>
-                                </Progress.Track>
-                            </Progress.Root>
+                                <Text fontSize="xs" color="whiteAlpha.900" fontWeight="medium" flexShrink={0}>
+                                    {Math.round(progress * 100)}%
+                                </Text>
+                            </Flex>
                         </Box>
                     )}
                 </Box>
+
+                {/* Book info + actions */}
+                <Stack flex={1} gap={4} align={{base: "center", md: "start"}} textAlign={{base: "center", md: "start"}} w="full">
+                    {/* Title & author · year */}
+                    <Box>
+                        <Heading size={{base: "xl", md: "2xl"}} mb={1}>{book.title}</Heading>
+                        <Flex align="center" gap={2} color="fg.muted" fontSize="md" justify={{base: "center", md: "start"}} flexWrap="wrap">
+                            {book.author && book.author.trim() ? (
+                                <Link
+                                    to={`/authors/${encodeURIComponent(book.author)}`}
+                                    style={{textDecoration: "none", color: "inherit"}}
+                                >
+                                    <Box as="span" _hover={{textDecoration: "underline"}}>{book.author}</Box>
+                                </Link>
+                            ) : (
+                                <Box as="span">{book.author || "Unknown Author"}</Box>
+                            )}
+                            {book.publishedYear && (
+                                <>
+                                    <Text as="span" color="fg.subtle" userSelect="none">·</Text>
+                                    <Text as="span" color="fg.subtle">{book.publishedYear}</Text>
+                                </>
+                            )}
+                        </Flex>
+                    </Box>
+
+                    {/* Unified action row: labeled CTAs + divider + icon actions */}
+                    <Flex align="center" gap={3} flexWrap="wrap" w={{base: "full", md: "auto"}} justify={{base: "center", md: "start"}}>
+                        <Button variant="solid" w={{base: "full", md: "auto"}} minW="120px" asChild>
+                            <Link to={`/books/${book.id}/read`}>
+                                <LuBookOpen/> Read
+                            </Link>
+                        </Button>
+                        <Button variant="outline" w={{base: "full", md: "auto"}} minW="130px" asChild>
+                            <a
+                                href={`${config.apiUrl}/books/${book.id}/download`}
+                                // Replace characters invalid in filenames with underscores
+                                download={`${book.title.replace(/[/\\:*?"<>|]/g, '_')}.epub`}
+                            >
+                                <LuDownload/> Download
+                            </a>
+                        </Button>
+                        {/* Vertical divider hidden on mobile */}
+                        <Box display={{base: "none", md: "block"}} w="1px" h="6" bg="border" alignSelf="center" flexShrink={0}/>
+                        <Flex gap={1} align="center" justify="center">
+                            <Tooltip content={book.isFavorite ? "Unfavorite" : "Favorite"}>
+                                <IconButton
+                                    variant="ghost"
+                                    onClick={() => updateBook({...book, isFavorite: !book.isFavorite})}
+                                >
+                                    <LuHeart
+                                        fill={book.isFavorite ? "red" : "none"}
+                                        color={book.isFavorite ? "red" : undefined}
+                                    />
+                                </IconButton>
+                            </Tooltip>
+                            <ManageBookShelvesButton bookId={book.id} variant="ghost"/>
+                            {/* Overflow menu for destructive / contextual actions */}
+                            <Menu.Root>
+                                <Menu.Trigger asChild>
+                                    <IconButton variant="ghost" aria-label="More options">
+                                        <LuEllipsis/>
+                                    </IconButton>
+                                </Menu.Trigger>
+                                <Portal>
+                                    <Menu.Positioner>
+                                        <Menu.Content>
+                                            {isCurrentlyReading && (
+                                                <Menu.Item
+                                                    value="stop-reading"
+                                                    onClick={() => removeCurrentlyReading(book.id)}
+                                                >
+                                                    <LuX/> Stop reading
+                                                </Menu.Item>
+                                            )}
+                                            <Menu.Item
+                                                value="delete"
+                                                color="fg.error"
+                                                onClick={() => setDeleteOpen(true)}
+                                            >
+                                                <LuTrash2/> Delete book
+                                            </Menu.Item>
+                                        </Menu.Content>
+                                    </Menu.Positioner>
+                                </Portal>
+                            </Menu.Root>
+                        </Flex>
+                    </Flex>
+                </Stack>
             </Flex>
+
+            {/* Delete confirmation dialog (controlled) */}
+            <Dialog.Root open={deleteOpen} onOpenChange={(e) => setDeleteOpen(e.open)}>
+                <Portal>
+                    <Dialog.Backdrop/>
+                    <Dialog.Positioner>
+                        <Dialog.Content p={1} textAlign="center">
+                            <Dialog.Header>
+                                <Dialog.Title>Delete book: {book.title}</Dialog.Title>
+                            </Dialog.Header>
+                            <Dialog.Body>Are you sure you want to delete this item?</Dialog.Body>
+                            <Dialog.Footer>
+                                <Dialog.ActionTrigger asChild>
+                                    <Button variant="ghost">Cancel</Button>
+                                </Dialog.ActionTrigger>
+                                <Button
+                                    variant="subtle"
+                                    color="fg.error"
+                                    disabled={pendingDelete}
+                                    onClick={() => deleteBook(book.id).then(result => !result.error && navigate("/"))}
+                                >
+                                    {pendingDelete ? <LuLoader/> : "Delete"}
+                                </Button>
+                            </Dialog.Footer>
+                            <Dialog.CloseTrigger asChild>
+                                <CloseButton/>
+                            </Dialog.CloseTrigger>
+                        </Dialog.Content>
+                    </Dialog.Positioner>
+                </Portal>
+            </Dialog.Root>
         </Box>
     );
 }


### PR DESCRIPTION
## Summary

Adds a download button to the book details page so users can download their EPUB files to read offline or on a different platform.

## Changes

- Added a `LuDownload` icon button to the action bar in `BookDetailsPage`
- The button links to `/api/uploads/books/{fileName}` (existing static file serving) with the `download` attribute set to the sanitized book title
- Book title is sanitized by replacing characters invalid in filenames (`/\:*?"<>|`) with underscores

## Acceptance Criteria

- ✅ As a user, I can click a download button on the book detail page to download my book as an EPUB file

## Notes

- The download currently uses the existing unauthenticated static file serving. A cross-layer issue has been created to add an authenticated download endpoint and restrict direct static access to book files: [Oghamark/homebranch#24](https://github.com/Oghamark/homebranch/issues/24)
- Once that backend issue is implemented, the `href` will be updated to call `GET /books/:id/download` with `credentials: 'include'`
