### PR TITLE
feat: display book summary on details page (#45)

### DIFF
--- a/src/entities/book/model/BookModel.ts
+++ b/src/entities/book/model/BookModel.ts
@@ -6,4 +6,5 @@ export type BookModel = {
     isFavorite: boolean;
     publishedYear: string;
     coverImageFileName: string;
+    summary?: string;
 }

--- a/src/entities/book/ui/AddBookButton.tsx
+++ b/src/entities/book/ui/AddBookButton.tsx
@@ -71,6 +71,7 @@ export function AddBookButton(buttonProps: ButtonProps) {
                     author: metadata.creator,
                     isFavorite: false,
                     publishedYear: new Date(metadata.pubdate).getFullYear().toString(),
+                    summary: metadata.description?.trim() || undefined,
                     file,
                     coverImage: coverImageBlob,
                 };

--- a/src/pages/bookDetails/ui/BookDetailsPage.tsx
+++ b/src/pages/bookDetails/ui/BookDetailsPage.tsx
@@ -137,6 +137,12 @@ export default function BookDetailsPage({book}: BookDetailsPageProps) {
                         </Flex>
                     </Box>
 
+                    {book.summary && book.summary.trim() && (
+                        <Text color="fg.muted" fontSize="sm" lineHeight="tall">
+                            {book.summary}
+                        </Text>
+                    )}
+
                     {/* Unified action row: labeled CTAs + divider + icon actions */}
                     <Flex align="center" gap={3} flexWrap="wrap" w={{base: "full", md: "auto"}} justify={{base: "center", md: "start"}}>
                         <Button variant="solid" w={{base: "full", md: "auto"}} minW="120px" asChild>


### PR DESCRIPTION
## Summary

Implements the book summary feature requested in #45. When a book has a summary (description), it is now displayed on the book details page below the title/author/year section.

## Changes

- **`BookModel`** — Added optional `summary?: string` field to the type definition.
- **`BookDetailsPage`** — Renders `book.summary` as muted body text beneath the title/author block, guarded against whitespace-only values.
- **`AddBookButton`** — Extracts `metadata.description` from the EPUB metadata during upload and sends it as `summary` in the create book request.

## Acceptance Criteria

✅ As a user, I can see a summary of the book I am viewing on the details page so that I can have an idea of what the book is about.

## Cross-layer dependency

A backend issue has been created at [Oghamark/homebranch#26](https://github.com/Oghamark/homebranch/issues/26) to add the `summary` field to the book database schema, DTOs, and API endpoints. The frontend will display summaries once the backend implements that issue and books are uploaded (or updated) with summary data.
