### PR TITLE
Render book summary as backend HTML with expand/collapse and Open Lib…

### DIFF
--- a/src/entities/book/api/api.ts
+++ b/src/entities/book/api/api.ts
@@ -172,6 +172,10 @@ export const booksApi = homebranchApi.injectEndpoints({
             query: (book: BookModel) => ({url: `/books/${book.id}`, method: 'PUT', body: book}),
             invalidatesTags: result => result ? [{type: 'Book' as const, id: result.id}] : []
         }),
+        generateBookSummary: build.mutation<BookModel, string>({
+            query: (id: string) => ({url: `/books/${id}/fetch-summary`, method: 'POST'}),
+            invalidatesTags: result => result ? [{type: 'Book' as const, id: result.id}] : []
+        }),
     }),
 });
 
@@ -184,4 +188,5 @@ export const {
     useCreateBookMutation,
     useUpdateBookMutation,
     useDeleteBookMutation,
+    useGenerateBookSummaryMutation,
 } = booksApi;

--- a/src/entities/book/index.ts
+++ b/src/entities/book/index.ts
@@ -15,6 +15,7 @@ export {
     useCreateBookMutation,
     useUpdateBookMutation,
     useDeleteBookMutation,
+    useGenerateBookSummaryMutation,
 } from "./api/api";
 
 export type {CreateBookRequest} from "./api/dtos";


### PR DESCRIPTION
…rary lookup

- Replace plain text summary rendering with dangerouslySetInnerHTML (backend now provides pre-rendered HTML)
- Add Summary component with expand/collapse (mirrors Biography component pattern)
- Add generateBookSummary mutation calling POST /books/:id/fetch-summary
- Show 'Look up summary on Open Library' button when no summary exists
- Toast info when Open Library returns no summary; toast error on request failure