### PR TITLE
feat: add ownership guardrails for book deletion (#8)

### DIFF
--- a/src/entities/book/api/dtos.ts
+++ b/src/entities/book/api/dtos.ts
@@ -1,6 +1,6 @@
 import type {BookModel} from "@/entities/book";
 
-export type CreateBookRequest = Omit<BookModel, "id" | "fileName" | "coverImageFileName"> & {
+export type CreateBookRequest = Omit<BookModel, "id" | "fileName" | "coverImageFileName" | "uploadedByUserId"> & {
     file: File,
     coverImage: Blob | undefined
 };

--- a/src/entities/book/model/BookModel.ts
+++ b/src/entities/book/model/BookModel.ts
@@ -7,4 +7,5 @@ export type BookModel = {
     publishedYear: string;
     coverImageFileName: string;
     summary?: string;
+    uploadedByUserId: string;
 }

--- a/src/pages/bookDetails/ui/BookDetailsPage.tsx
+++ b/src/pages/bookDetails/ui/BookDetailsPage.tsx
@@ -60,6 +60,10 @@ export default function BookDetailsPage({book}: BookDetailsPageProps) {
     const navigate = useNavigate();
     const [deleteOpen, setDeleteOpen] = useState(false);
 
+    const currentUserId = sessionStorage.getItem('user_id');
+    const currentUserRole = sessionStorage.getItem('user_role');
+    const canDelete = currentUserRole === 'ADMIN' || currentUserId === book.uploadedByUserId;
+
     const [isCurrentlyReading, setIsCurrentlyReading] = useState(
         isBookOpenedLocally(book.id)
     );
@@ -240,13 +244,15 @@ export default function BookDetailsPage({book}: BookDetailsPageProps) {
                                                     <LuX/> Stop reading
                                                 </Menu.Item>
                                             )}
-                                            <Menu.Item
-                                                value="delete"
-                                                color="fg.error"
-                                                onClick={() => setDeleteOpen(true)}
-                                            >
-                                                <LuTrash2/> Delete book
-                                            </Menu.Item>
+                                            {canDelete && (
+                                                <Menu.Item
+                                                    value="delete"
+                                                    color="fg.error"
+                                                    onClick={() => setDeleteOpen(true)}
+                                                >
+                                                    <LuTrash2/> Delete book
+                                                </Menu.Item>
+                                            )}
                                         </Menu.Content>
                                     </Menu.Positioner>
                                 </Portal>


### PR DESCRIPTION
Implements the frontend portion of issue #8.

Changes:
- Add uploadedByUserId field to BookModel
- Exclude uploadedByUserId from CreateBookRequest (server assigns it)
- Hide Delete book menu item unless current user is the uploader or ADMIN

Closes #8