### PR TITLE
Improve Raspberry Pi/local HTTP support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,47 @@
+name: Build and publish ARM64 Docker image
+
+on:
+  push:
+    branches:
+      - raspberry-pi-arm64-support
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/skyeblu7/homebranch-web
+
+jobs:
+  docker-arm64:
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push ARM64 image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          build-args: |
+            VITE_API_URL=/api
+            VITE_AUTHENTICATION_URL=/auth
+            VITE_ITEMS_PER_PAGE=24
+          tags: |
+            ${{ env.IMAGE_NAME }}:arm64
+            ${{ env.IMAGE_NAME }}:raspberry-pi
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:20-alpine AS build
 WORKDIR /app
-ARG VITE_API_URL
-ARG VITE_AUTHENTICATION_URL
-ARG VITE_ITEMS_PER_PAGE
+ARG VITE_API_URL=/api
+ARG VITE_AUTHENTICATION_URL=/auth
+ARG VITE_ITEMS_PER_PAGE=24
 COPY package*.json ./
 RUN npm ci
 COPY . .
@@ -10,6 +10,13 @@ RUN npm run build
 
 FROM nginx:alpine
 COPY --from=build /app/build/client /usr/share/nginx/html
+
+
+# HomeBranch/readium adds upgrade-insecure-requests inside reader iframe CSP.
+# On local HTTP installs this upgrades EPUB resource URLs to HTTPS and breaks images/styles.
+RUN grep -RIl "upgrade-insecure-requests" /usr/share/nginx/html/assets | xargs -r sed -i 's/"upgrade-insecure-requests",//g'
+
+
 RUN rm /etc/nginx/conf.d/default.conf
 COPY default.conf.template /etc/nginx/templates/default.conf.template
 EXPOSE 80

--- a/default.conf.template
+++ b/default.conf.template
@@ -14,7 +14,9 @@ server {
     # SSE endpoints — disable buffering so events are delivered immediately
     location ~ ^/api/(jobs/stream|library/events)$ {
         proxy_pass ${API_BACKEND}/$1;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
@@ -28,15 +30,28 @@ server {
 
     location /api/ {
         proxy_pass ${API_BACKEND}/;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Prefix /api;
     }
 
+
+#    location ~ ^/(login|sign-up|logout|refresh|me|config|users|oidc) {
+#        proxy_pass ${AUTH_BACKEND}$request_uri;
+#        proxy_set_header Host $host;
+#        proxy_set_header X-Real-IP $remote_addr;
+#        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#    }
+
+
     location /auth/ {
         proxy_pass ${AUTH_BACKEND}/;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }


### PR DESCRIPTION
This PR improves Raspberry Pi/local HTTP deployments of HomeBranch Web.

Changes:
- Preserves the forwarded host including non-standard ports by using `$http_host` instead of `$host` in nginx proxy headers.
- Adds ARM64 Docker image publishing for Raspberry Pi deployments.
- Includes a local HTTP workaround for Readium’s `upgrade-insecure-requests` CSP behavior, which otherwise rewrites EPUB resource URLs from HTTP to HTTPS and breaks images/styles on LAN-only deployments.

Tested:
- Built and published ARM64 web image successfully.
- Verified the image pulls on Raspberry Pi / ARM64.
- Verified HomeBranch Web works on `http://LAN-IP:PORT`.
- Verified EPUB XHTML, image, and style resources load correctly in the reader.